### PR TITLE
Name the plugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ php:
  
 before_script:
   - git clone --depth 1 git://github.com/cakephp/cakephp ../cakephp && cd ../cakephp
-  - mv ../cakephp-currency-converter plugins/CurrencyConverter
+  - mv ../CurrencyConverter plugins/CurrencyConverter
   - chmod -R 777 ../cakephp/app/tmp
   - composer global require 'phpunit/phpunit=3.7.33'
   - ln -s ~/.composer/vendor/phpunit/phpunit/PHPUnit ../cakephp/vendors/PHPUnit

--- a/composer.json
+++ b/composer.json
@@ -28,4 +28,7 @@
       "ext-curl": "*",
       "composer/installers": "*"
     }
+  "extra": {
+    "installer-name": "CurrencyConverter"
+  }
 }


### PR DESCRIPTION
I've opened this PR as a suggestion really. Having installed the plugin it is using it's full repo name as the folder which looks a bit messy. `CakephpCurrencyConverter` seems to me like including `Cakephp` when it's inside my app is a bit redundant.

This change will allow it to be installed without it's framework prefix, making the Plugin folder look a bit cleaner.

Thanks